### PR TITLE
Add support for CI

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <name>MinecraftForge_reposilite Config DSL Script</name>
+  <groupId>MinecraftForge_reposilite</groupId>
+  <artifactId>MinecraftForge_reposilite_dsl</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.jetbrains.teamcity</groupId>
+    <artifactId>configs-dsl-kotlin-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>jetbrains-all</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>teamcity-server</id>
+      <url>https://teamcity.minecraftforge.net/app/dsl-plugins-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>JetBrains</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <sourceDirectory>${basedir}</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+
+        <configuration/>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>process-test-sources</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.teamcity</groupId>
+        <artifactId>teamcity-configs-maven-plugin</artifactId>
+        <version>${teamcity.dsl.version}</version>
+        <configuration>
+          <format>kotlin</format>
+          <dstDir>target/generated-configs</dstDir>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin</artifactId>
+      <version>${teamcity.dsl.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin-plugins</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>pom</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-script-runtime</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -32,6 +32,8 @@ project {
     buildType(PullRequests)
 
     params {
+        text("docker_jdk_version", "8", label = "Gradle version", description = "The version of the JDK to use during execution of tasks in a JDK.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("docker_gradle_version", "7.2", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("git_main_branch", "master", label = "Git Main Branch", description = "The git main or default branch to use in VCS operations.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("github_repository_name", "reposilite", label = "The github repository name. Used to connect to it in VCS Roots.", description = "This is the repository slug on github. So for example `reposilite` or `MinecraftForge`. It is interpolated into the global VCS Roots.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("env.PUBLISHED_JAVA_ARTIFACT_ID", "reposilite", label = "Published artifact id", description = "The maven coordinate artifact id that has been published by this build. Can not be empty.", allowEmpty = false)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,0 +1,69 @@
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubIssues
+
+/*
+The settings script is an entry point for defining a TeamCity
+project hierarchy. The script should contain a single call to the
+project() function with a Project instance or an init function as
+an argument.
+
+VcsRoots, BuildTypes, Templates, and subprojects can be
+registered inside the project using the vcsRoot(), buildType(),
+template(), and subProject() methods respectively.
+
+To debug settings scripts in command-line, run the
+
+    mvnDebug org.jetbrains.teamcity:teamcity-configs-maven-plugin:generate
+
+command and attach your debugger to the port 8000.
+
+To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
+-> Tool Windows -> Maven Projects), find the generate task node
+(Plugins -> teamcity-configs -> teamcity-configs:generate), the
+'Debug' option is available in the context menu for the task.
+*/
+
+version = "2021.2"
+
+project {
+
+    buildType(Build)
+    buildType(BuildSecondaryBranches)
+    buildType(PullRequests)
+
+    params {
+        text("git_main_branch", "master", label = "Git Main Branch", description = "The git main or default branch to use in VCS operations.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("github_repository_name", "reposilite", label = "The github repository name. Used to connect to it in VCS Roots.", description = "This is the repository slug on github. So for example `reposilite` or `MinecraftForge`. It is interpolated into the global VCS Roots.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("env.PUBLISHED_JAVA_ARTIFACT_ID", "reposilite", label = "Published artifact id", description = "The maven coordinate artifact id that has been published by this build. Can not be empty.", allowEmpty = false)
+        text("env.PUBLISHED_JAVA_GROUP", "net.minecraftforge", label = "Published group", description = "The maven coordinate group that has been published by this build. Can not be empty.", allowEmpty = false)
+    }
+
+    features {
+        githubIssues {
+            id = "reposilite__IssueTracker"
+            displayName = "MinecraftForge/reposilite"
+            repositoryURL = "https://github.com/MinecraftForge/reposilite"
+        }
+    }
+}
+
+object Build : BuildType({
+    templates(AbsoluteId("MinecraftForge_SetupGradleUtilsCiEnvironmen"), AbsoluteId("MinecraftForge_BuildWithDiscordNotifications"), AbsoluteId("MinecraftForge_BuildMainBranches"), AbsoluteId("MinecraftForge_BuildUsingGradle"), AbsoluteId("MinecraftForge_PublishProjectUsingGradle"), AbsoluteId("MinecraftForge_TriggersStaticFilesWebpageGenerator"))
+    id("reposilite__Build")
+    name = "Build"
+    description = "Builds and Publishes the main branches of the project."
+})
+
+object BuildSecondaryBranches : BuildType({
+    templates(AbsoluteId("MinecraftForge_ExcludesBuildingDefaultBranch"), AbsoluteId("MinecraftForge_SetupGradleUtilsCiEnvironmen"), AbsoluteId("MinecraftForge_BuildWithDiscordNotifications"), AbsoluteId("MinecraftForge_BuildMainBranches"), AbsoluteId("MinecraftForge_BuildUsingGradle"))
+    id("reposilite__BuildSecondaryBranches")
+    name = "Build - Secondary Branches"
+    description = "Builds and Publishes the secondary branches of the project."
+})
+
+object PullRequests : BuildType({
+    templates(AbsoluteId("MinecraftForge_BuildPullRequests"), AbsoluteId("MinecraftForge_SetupGradleUtilsCiEnvironmen"), AbsoluteId("MinecraftForge_BuildWithDiscordNotifications"), AbsoluteId("MinecraftForge_BuildUsingGradle"))
+    id("reposilite__PullRequests")
+    name = "Pull Requests"
+    description = "Builds pull requests for the project"
+})

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -52,6 +52,44 @@ object Build : BuildType({
     id("reposilite__Build")
     name = "Build"
     description = "Builds and Publishes the main branches of the project."
+
+    steps {
+        dockerCommand {
+            name = "Build Image"
+            id = "reposilite__build_image"
+            commandType = build {
+                source = file {
+                    path = "Dockerfile"
+                }
+                contextDir = "."
+                namesAndTags = """
+                containers.minecraftforge.net/reposilite:latest
+                containers.minecraftforge.net/reposilite:%env.BUILD_NUMBER%
+            """.trimIndent()
+                commandArgs = "--pull"
+            }
+            param("dockerImage.platform", "linux")
+        }
+        dockerCommand {
+            name = "Push Image"
+            id = "reposilite__push_image"
+            commandType = push {
+                namesAndTags = """
+                containers.minecraftforge.net/reposilite:latest
+                containers.minecraftforge.net/reposilite:%env.BUILD_NUMBER%
+            """.trimIndent()
+            }
+        }
+    }
+
+    features {
+        dockerSupport {
+            id = "reposilite__DockerSupport"
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_7"
+            }
+        }
+    }
 })
 
 object BuildSecondaryBranches : BuildType({

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.avast.gradle.docker-compose' version '0.14.9'
+    id 'net.minecraftforge.gradleutils' version '2.+'
 }
 
 evaluationDependsOnChildren()
@@ -9,4 +10,8 @@ composeBuild {
     doFirst {
         dockerCompose.environment.put('REP_VERSION', project(':backend').version)
     }
+}
+
+changelog {
+    fromTag '2.10'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+enableLocalRepoDirectory=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/reposilite-backend/build.gradle
+++ b/reposilite-backend/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '7.0.0'
-    id 'net.minecraftforge.gradleutils' version '1.+'
+    id 'net.minecraftforge.gradleutils'
     id 'java'
     id 'groovy'
     id 'maven-publish'

--- a/reposilite-backend/build.gradle
+++ b/reposilite-backend/build.gradle
@@ -50,6 +50,7 @@ test {
 jacocoTestReport.dependsOn(test)
 
 shadowJar {
+    minimize()
     mergeServiceFiles()
     exclude('META-INF/resources/')
     exclude('META-INF/com.android.tools/')
@@ -102,23 +103,45 @@ java {
 
 publishing {
     publications {
-        maven(MavenPublication) {
-            from(components.java) // TODO: Don't include shadowjar somehow? Or severly work on making it skinnier
-            artifactId = project.archivesBaseName
+        mavenJava(MavenPublication) {
+            //TODO: For now we minimize the shadowJar, if that fails we might need a different solution.
+            from components.java
+
+            pom {
+                name = 'Reposilite'
+                description = 'Lightweight repository manager for Maven based artifacts.'
+                url = 'https://github.com/MinecraftForge/Reposilite'
+                scm {
+                    url = 'https://github.com/MinecraftForge/Reposilite'
+                    connection = 'scm:git:git://github.com/MinecraftForge/Reposilite.git'
+                    developerConnection = 'scm:git:git@github.com:MinecraftForge/Reposilite.git'
+                }
+                issueManagement {
+                    system = 'github'
+                    url = 'https://github.com/MinecraftForge/Reposilite/issues'
+                }
+
+                licenses {
+                    license {
+                        name = 'Apache 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'LexManos'
+                        name = 'Lex Manos'
+                    }
+                }
+            }
         }
     }
     repositories {
-        maven {
-            if (System.env.MAVEN_USER) {
-                url 'https://maven.minecraftforge.net/'
-                authentication {
-                    basic(BasicAuthentication)
-                }
-                credentials {
-                    username = System.env.MAVEN_USER ?: 'not'
-                    password = System.env.MAVEN_PASSWORD ?: 'set'
-                }
-            } else {
+        maven gradleutils.getPublishingForgeMaven()
+        if (project.enableLocalRepoDirectory == 'true') {
+            maven {
+                name 'RepoDirectory'
                 url 'file://' + rootProject.file('repo').getAbsolutePath()
             }
         }

--- a/reposilite-frontend/build.gradle
+++ b/reposilite-frontend/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'net.minecraftforge.gradleutils' version '1.+'
+    id 'net.minecraftforge.gradleutils'
     id 'com.github.node-gradle.node' version '3.0.1'
 }
 


### PR DESCRIPTION
This adds supports for TeamCity.

- Main branch switched to `master`
- Gradle 7.2
- JDK 8
- Docker support enabled
- Additional tasks to build and push docker images for `reposilite`.
- Updated to GradleUtils `2.+`
- Enable publishing
- Minimize the shadow jar
- Update to Gradle `7.4.2`