### PR TITLE
Enable running as root user in CI environment

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -34,11 +34,12 @@ project {
 
     params {
         text("docker_jdk_version", "8", label = "Gradle version", description = "The version of the JDK to use during execution of tasks in a JDK.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
-        text("docker_gradle_version", "7.2", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("docker_gradle_version", "7.4.2", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("git_main_branch", "master", label = "Git Main Branch", description = "The git main or default branch to use in VCS operations.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("github_repository_name", "reposilite", label = "The github repository name. Used to connect to it in VCS Roots.", description = "This is the repository slug on github. So for example `reposilite` or `MinecraftForge`. It is interpolated into the global VCS Roots.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("env.PUBLISHED_JAVA_ARTIFACT_ID", "reposilite", label = "Published artifact id", description = "The maven coordinate artifact id that has been published by this build. Can not be empty.", allowEmpty = false)
         text("env.PUBLISHED_JAVA_GROUP", "net.minecraftforge", label = "Published group", description = "The maven coordinate group that has been published by this build. Can not be empty.", allowEmpty = false)
+        param("docker_additional_args", "-u 0")
     }
 
     features {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ plugins {
 
 evaluationDependsOnChildren()
 
+def rootProjectVersion = gradleutils.getTagOffsetVersion()
+allprojects {pro -> pro.version = rootProjectVersion}
+
 composeBuild {
     dependsOn(':backend:shadowJar')
     doFirst {


### PR DESCRIPTION
Due to a difference in how the workspace is mounted on the TeamCity CI environment (vs. my personal TeamCity Test setup) the user running the build for Reposilite needs to be root (to be able to override the ownership handling of both the teamcity agent container (running as the teamcity user) as well as the gradle runtime (running as the gradle user)).

Additionally this updates the runtime gradle environment, so that for now no gradle wrapper needs to be downloaded, and the version is forced on all projects.